### PR TITLE
chore(CHANGELOG): update to v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,7 @@ All notable changes to [zeebe-dmn-moddle](https://github.com/camunda/zeebe-dmn-m
 
 ___Note:__ Yet to be released changes appear here._
 
+## 1.0.0
+
 * `FEAT`: support `zeebe:VersionTag` [679dc7](https://github.com/camunda/zeebe-dmn-moddle/commit/679dc7edf7f02edc58af5e5ff2981118ce312cc5)
+* `CHORE`: first release :tada:


### PR DESCRIPTION
Please have a look at this new repository. It mirrors [zeebe-bpmn-moddle](https://github.com/camunda/zeebe-bpmn-moddle) and adds a `zeebe:VersionTag` extension element as required by https://github.com/camunda/product-hub/issues/435.